### PR TITLE
EREGCSC-178: Revise url pattern declarations in regulations-site

### DIFF
--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -39,141 +39,141 @@ urlpatterns = [
     # Redirect to version by date (by GET)
     # Example http://.../regulation_redirect/201-3-v
     url(r'^regulation_redirect/(?P<label_id>[-\w]+)$',
-            redirect_by_date_get, name='redirect_by_date_get'),
+        redirect_by_date_get, name='redirect_by_date_get'),
 
     # Redirect to a diff based on GET params
     # Example http://.../diff_redirect/201-3/old_version?new_version=new
     url(r'^diff_redirect/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$',
-            diff_redirect, name='diff_redirect'),
+        diff_redirect, name='diff_redirect'),
 
     # A section by section paragraph with chrome
     # Example: http://.../sxs/201-2-g/2011-1738
     url(r'^sxs/(?P<label_id>[-\w]+)/(?P<notice_id>[-\d\w_]+)$',
-            lt_cache(ChromeSXSView.as_view()), name='chrome_sxs_view'),
+        lt_cache(ChromeSXSView.as_view()), name='chrome_sxs_view'),
 
     # Search results for non-JS viewers
     # Example: http://.../search?q=term&version=2011-1738
     url(r'^search(?:/cfr)?/(?P<label_id>[\d]+)$',
-            ChromeSearchView.as_view(),
-            name='chrome_search',
-            kwargs={'doc_type': 'cfr'}),
+        ChromeSearchView.as_view(),
+        name='chrome_search',
+        kwargs={'doc_type': 'cfr'}),
     url(r'^search/preamble/(?P<label_id>[\w]+)$',
-            ChromePreambleSearchView.as_view(),
-            name='chrome_search_preamble',
-            kwargs={'doc_type': 'preamble'}),
+        ChromePreambleSearchView.as_view(),
+        name='chrome_search_preamble',
+        kwargs={'doc_type': 'preamble'}),
  
     # Diff view of a section for non-JS viewers (or book markers)
     # Example: http://.../diff/201-4/2011-1738/2013-10704
     url(r'^diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$',
-            lt_cache(ChromeSectionDiffView.as_view()), name='chrome_section_diff_view'),
+        lt_cache(ChromeSectionDiffView.as_view()), name='chrome_section_diff_view'),
     url(r'^preamble/(?P<doc_number>[\w-]+)/cfr_changes/(?P<section>[\w-]+)$',
-            daily_cache(CFRChangesView.as_view()), name='cfr_changes'),
+        daily_cache(CFRChangesView.as_view()), name='cfr_changes'),
     url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$',
-            daily_cache(PreambleView.as_view()), name='chrome_preamble'),
+        daily_cache(PreambleView.as_view()), name='chrome_preamble'),
 
     # Redirect to version by date
     # Example: http://.../201-3-v/1999/11/8
     url(r'^(?P<label_id>[-\w]+)/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})$',
-            redirect_by_date, name='redirect_by_date'),
+        redirect_by_date, name='redirect_by_date'),
  
     # Redirect to version by current date
     # Example: http://.../201-3-v/CURRENT
     url(r'^(?P<label_id>[-\w]+)/CURRENT$',
-            redirect_by_current_date, name='redirect_by_current_date'),
+        redirect_by_current_date, name='redirect_by_current_date'),
 
     # A regulation section with chrome
     # Example: http://.../201-4/2013-10704
     url(r'^(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$',
-            lt_cache(ChromeView.as_view(partial_class=PartialSectionView)),
-            name='chrome_section_view'),
+        lt_cache(ChromeView.as_view(partial_class=PartialSectionView)),
+        name='chrome_section_view'),
         
     # Subterp, interpretations of a while subpart, emptypart or appendices
     # Example: http://.../201-Subpart-A-Interp/2013-10706
     #          http://.../201-Subpart-Interp/2013-10706
     #          http://.../201-Appendices-Interp/2013-10706
     url(r'^(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)/(?P<version>[-\d\w_]+)$',
-            lt_cache(ChromeSubterpView.as_view()), name=ChromeSubterpView.version_switch_view),
+        lt_cache(ChromeSubterpView.as_view()), name=ChromeSubterpView.version_switch_view),
 
     # Interpretation of a section/paragraph or appendix
     # Example: http://.../201-4-Interp/2013-10704
     url(r'^(?P<label_id>[-\w]+[-]Interp)/(?P<version>[-\d\w_]+)$',
-            lt_cache(ChromeView.as_view(partial_class=partial_interp.PartialInterpView)),
-            name='chrome_interp_view'),
+        lt_cache(ChromeView.as_view(partial_class=partial_interp.PartialInterpView)),
+        name='chrome_interp_view'),
 
     # The whole regulation with chrome
     # Example: http://.../201/2013-10704
     url(r'^(?P<label_id>[\d]+)/(?P<version>[-\d\w_]+)$',
-            lt_cache(ChromeView.as_view(
-                partial_class=PartialRegulationView,
-                version_switch_view='chrome_regulation_view')),
-            name='chrome_regulation_view'),
+        lt_cache(ChromeView.as_view(
+            partial_class=PartialRegulationView,
+            version_switch_view='chrome_regulation_view')),
+         name='chrome_regulation_view'),
 
     # A regulation paragraph with chrome
     # Example: http://.../201-2-g/2013-10704
     url(r'^(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
-            lt_cache(ChromeView.as_view(
-                partial_class=PartialParagraphView,
-                version_switch_view='chrome_paragraph_view')),
-            name='chrome_paragraph_view'),
+        lt_cache(ChromeView.as_view(
+            partial_class=PartialParagraphView,
+            version_switch_view='chrome_paragraph_view')),
+        name='chrome_paragraph_view'),
 
     # A regulation landing page
     # Example: http://.../201
     url(r'^(?P<label_id>[\d]+)$',
-            ChromeLandingView.as_view(), name='regulation_landing_view'),
+        ChromeLandingView.as_view(), name='regulation_landing_view'),
 
     # Load just the sidebar
     # Example: http://.../partial/sidebar/201-2/2013-10704
     url(r'^partial/sidebar/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
-            SideBarView.as_view(), name='sidebar'),
+        SideBarView.as_view(), name='sidebar'),
 
     # Load just search results
     url(r'^partial/search(?:/cfr)?/(?P<label_id>[\d]+)$',
-            PartialSearch.as_view(),
-            name='partial_search',
-            kwargs={'doc_type': 'cfr'}),
+        PartialSearch.as_view(),
+        name='partial_search',
+        kwargs={'doc_type': 'cfr'}),
     url(r'^partial/search/preamble/(?P<label_id>[\w]+)$',
-            PartialSearch.as_view(),
-            name='partial_search',
-            kwargs={'doc_type': 'preamble'}),
+        PartialSearch.as_view(),
+        name='partial_search',
+        kwargs={'doc_type': 'preamble'}),
 
     # A diff view of a section (without chrome)
     url(r'^partial/diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$',
-            lt_cache(PartialSectionDiffView.as_view()), name='partial_section_diff_view'),
+        lt_cache(PartialSectionDiffView.as_view()), name='partial_section_diff_view'),
 
     # A section by section paragraph (without chrome)
     # Example: http://.../partial/sxs/201-2-g/2011-1738
     url(r'^partial/sxs/(?P<label_id>[-\w]+)/(?P<notice_id>[-\d\w_]+)$',
-            lt_cache(ParagraphSXSView.as_view()), name='paragraph_sxs_view'),
+        lt_cache(ParagraphSXSView.as_view()), name='paragraph_sxs_view'),
 
     # A definition templated to be displayed in the sidebar (without chrome)
     # Example: http://.../partial/definition/201-2-g/2011-1738
     url(r'^partial/definition/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
-            lt_cache(PartialDefinitionView.as_view()), name='partial_definition_view'),
+        lt_cache(PartialDefinitionView.as_view()), name='partial_definition_view'),
 
     # A regulation section without chrome
     # Example: http://.../partial/201-4/2013-10704
     url(r'^partial/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$',
-            lt_cache(PartialSectionView.as_view()), name='partial_section_view'),
+        lt_cache(PartialSectionView.as_view()), name='partial_section_view'),
 
     # Subterp, interpretations of a whole subpart, emptypart or appendices
     # Example: http://.../partial/201-Subpart-A-Interp/2013-10706
     #          http://.../partial/201-Subpart-Interp/2013-10706
     #          http://.../partial/201-Appendices-Interp/2013-10706
     url(r'^partial/(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)/(?P<version>[-\d\w_]+)$',
-            lt_cache(partial_interp.PartialSubterpView.as_view()), name='partial_subterp_view'),
+        lt_cache(partial_interp.PartialSubterpView.as_view()), name='partial_subterp_view'),
 
     # An interpretation of a section/paragraph or appendix without chrome.
     # Example: http://.../partial/201-2-Interp/2013-10704
     url(r'^partial/(?P<label_id>[-\w]+[-]Interp)/(?P<version>[-\d\w_]+)$',
-            lt_cache(partial_interp.PartialInterpView.as_view()), name='partial_interp_view'),
+        lt_cache(partial_interp.PartialInterpView.as_view()), name='partial_interp_view'),
 
     # The whole regulation without chrome; not too useful; added for symmetry
     # Example: http://.../partial/201/2013-10704
     url(r'^partial/(?P<label_id>[\d]+)/(?P<version>[-\d\w_]+)$',
-            lt_cache(PartialRegulationView.as_view()), name='partial_regulation_view'),
+        lt_cache(PartialRegulationView.as_view()), name='partial_regulation_view'),
 
     # A regulation paragraph without chrome.
     # Example: http://.../partial/201-2-g/2013-10704
     url(r'^partial/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
-            lt_cache(PartialParagraphView.as_view()), name='partial_paragraph_view'),
+        lt_cache(PartialParagraphView.as_view()), name='partial_paragraph_view'),
 ]

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -61,7 +61,7 @@ urlpatterns = [
         ChromePreambleSearchView.as_view(),
         name='chrome_search_preamble',
         kwargs={'doc_type': 'preamble'}),
- 
+
     # Diff view of a section for non-JS viewers (or book markers)
     # Example: http://.../diff/201-4/2011-1738/2013-10704
     url(r'^diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$',
@@ -75,7 +75,7 @@ urlpatterns = [
     # Example: http://.../201-3-v/1999/11/8
     url(r'^(?P<label_id>[-\w]+)/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})$',
         redirect_by_date, name='redirect_by_date'),
- 
+
     # Redirect to version by current date
     # Example: http://.../201-3-v/CURRENT
     url(r'^(?P<label_id>[-\w]+)/CURRENT$',
@@ -86,7 +86,7 @@ urlpatterns = [
     url(r'^(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$',
         lt_cache(ChromeView.as_view(partial_class=PartialSectionView)),
         name='chrome_section_view'),
-        
+
     # Subterp, interpretations of a while subpart, emptypart or appendices
     # Example: http://.../201-Subpart-A-Interp/2013-10706
     #          http://.../201-Subpart-Interp/2013-10706
@@ -106,7 +106,7 @@ urlpatterns = [
         lt_cache(ChromeView.as_view(
             partial_class=PartialRegulationView,
             version_switch_view='chrome_regulation_view')),
-         name='chrome_regulation_view'),
+        name='chrome_regulation_view'),
 
     # A regulation paragraph with chrome
     # Example: http://.../201-2-g/2013-10704

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -27,156 +27,110 @@ from regulations.views.redirect import (
 from regulations.views.sidebar import SideBarView
 from regulations.views.universal_landing import universal
 
-# Re-usable URL patterns.
-meta_version = r'(?P<%s>[-\d\w_]+)'
-version_pattern = meta_version % 'version'
-newer_version_pattern = meta_version % 'newer_version'
-notice_pattern = meta_version % 'notice_id'
-
-reg_pattern = r'(?P<label_id>[\d]+)'
-preamble_pattern = r'(?P<label_id>[\w]+)'
-section_pattern = r'(?P<label_id>[\d]+[-][\w]+)'
-interp_pattern = r'(?P<label_id>[-\w]+[-]Interp)'
-paragraph_pattern = r'(?P<label_id>[-\w]+)'
-subterp_pattern = r'(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)'
-
-
 urlpatterns = [
+    # Index page
+    # Example http://.../
     url(r'^$', universal, name='universal_landing'),
-    # about page
+
+    # About page
+    # Example http://.../about
     url(r'^about$', about, name='about'),
+
     # Redirect to version by date (by GET)
     # Example http://.../regulation_redirect/201-3-v
-    url(r'^regulation_redirect/%s$' % paragraph_pattern, redirect_by_date_get,
-        name='redirect_by_date_get'),
+    url(r'^regulation_redirect/(?P<label_id>[-\w]+)$', redirect_by_date_get, name='redirect_by_date_get'),
+
     # Redirect to a diff based on GET params
     # Example http://.../diff_redirect/201-3/old_version?new_version=new
-    url(r'^diff_redirect/%s/%s$' % (section_pattern, version_pattern),
-        diff_redirect, name='diff_redirect'),
+    url(r'^diff_redirect/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$', diff_redirect, name='diff_redirect'),
+
     # A section by section paragraph with chrome
     # Example: http://.../sxs/201-2-g/2011-1738
-    url(r'^sxs/%s/%s$' % (paragraph_pattern, notice_pattern),
-        lt_cache(ChromeSXSView.as_view()),
-        name='chrome_sxs_view'),
+    url(r'^sxs/(?P<label_id>[-\w]+)/(?P<notice_id>[-\d\w_]+)$', lt_cache(ChromeSXSView.as_view()), name='chrome_sxs_view'),
+
     # Search results for non-JS viewers
     # Example: http://.../search?q=term&version=2011-1738
-    url(r'^search(?:/cfr)?/%s$' % reg_pattern,
-        ChromeSearchView.as_view(), name='chrome_search',
-        kwargs={'doc_type': 'cfr'}),
-    url(r'^search/preamble/%s$' % preamble_pattern,
-        ChromePreambleSearchView.as_view(), name='chrome_search_preamble',
-        kwargs={'doc_type': 'preamble'}),
+    url(r'^search(?:/cfr)?/(?P<label_id>[\d]+)$', ChromeSearchView.as_view(), name='chrome_search', kwargs={'doc_type': 'cfr'}),
+    url(r'^search/preamble/(?P<label_id>[\w]+)$', ChromePreambleSearchView.as_view(), name='chrome_search_preamble', kwargs={'doc_type': 'preamble'}),
+ 
     # Diff view of a section for non-JS viewers (or book markers)
     # Example: http://.../diff/201-4/2011-1738/2013-10704
-    url(r'^diff/%s/%s/%s$' %
-        (section_pattern, version_pattern, newer_version_pattern),
-        lt_cache(ChromeSectionDiffView.as_view()),
-        name='chrome_section_diff_view'),
-
-    url(r'^preamble/(?P<doc_number>[\w-]+)/cfr_changes/(?P<section>[\w-]+)$',
-        daily_cache(CFRChangesView.as_view()), name='cfr_changes'),
-    url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$',
-        daily_cache(PreambleView.as_view()), name='chrome_preamble'),
+    url(r'^diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$', lt_cache(ChromeSectionDiffView.as_view()), name='chrome_section_diff_view'),
+    url(r'^preamble/(?P<doc_number>[\w-]+)/cfr_changes/(?P<section>[\w-]+)$', daily_cache(CFRChangesView.as_view()), name='cfr_changes'),
+    url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$', daily_cache(PreambleView.as_view()), name='chrome_preamble'),
 
     # Redirect to version by date
     # Example: http://.../201-3-v/1999/11/8
-    url(r'^%s/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})$'
-        % paragraph_pattern, redirect_by_date, name='redirect_by_date'),
+    url(r'^(?P<label_id>[-\w]+)/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})$', redirect_by_date, name='redirect_by_date'),
+ 
     # Redirect to version by current date
     # Example: http://.../201-3-v/CURRENT
-    url(r'^%s/CURRENT$' % paragraph_pattern,
-        redirect_by_current_date, name='redirect_by_current_date'),
+    url(r'^(?P<label_id>[-\w]+)/CURRENT$', redirect_by_current_date, name='redirect_by_current_date'),
+
     # A regulation section with chrome
     # Example: http://.../201-4/2013-10704
-    url(r'^%s/%s$' % (section_pattern, version_pattern),
-        lt_cache(ChromeView.as_view(partial_class=PartialSectionView)),
-        name='chrome_section_view'),
+    url(r'^(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$', lt_cache(ChromeView.as_view(partial_class=PartialSectionView)), name='chrome_section_view'),
+        
     # Subterp, interpretations of a while subpart, emptypart or appendices
     # Example: http://.../201-Subpart-A-Interp/2013-10706
     #          http://.../201-Subpart-Interp/2013-10706
     #          http://.../201-Appendices-Interp/2013-10706
-    url(r'^%s/%s$' % (subterp_pattern, version_pattern),
-        lt_cache(ChromeSubterpView.as_view()),
-        name=ChromeSubterpView.version_switch_view),
+    url(r'^(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)/(?P<version>[-\d\w_]+)$', lt_cache(ChromeSubterpView.as_view()), name=ChromeSubterpView.version_switch_view),
+
     # Interpretation of a section/paragraph or appendix
     # Example: http://.../201-4-Interp/2013-10704
-    url(r'^%s/%s$' % (interp_pattern, version_pattern),
-        lt_cache(ChromeView.as_view(
-            partial_class=partial_interp.PartialInterpView)),
-        name='chrome_interp_view'),
+    url(r'^(?P<label_id>[-\w]+[-]Interp)/(?P<version>[-\d\w_]+)$', lt_cache(ChromeView.as_view(partial_class=partial_interp.PartialInterpView)), name='chrome_interp_view'),
+
     # The whole regulation with chrome
     # Example: http://.../201/2013-10704
-    url(r'^%s/%s$' % (reg_pattern, version_pattern),
-        lt_cache(ChromeView.as_view(
-            partial_class=PartialRegulationView,
-            version_switch_view='chrome_regulation_view')),
-        name='chrome_regulation_view'),
+    url(r'^(?P<label_id>[\d]+)/(?P<version>[-\d\w_]+)$', lt_cache(ChromeView.as_view(partial_class=PartialRegulationView, version_switch_view='chrome_regulation_view')), name='chrome_regulation_view'),
+
     # A regulation paragraph with chrome
     # Example: http://.../201-2-g/2013-10704
-    url(r'^%s/%s$' % (paragraph_pattern, version_pattern),
-        lt_cache(ChromeView.as_view(
-            partial_class=PartialParagraphView,
-            version_switch_view='chrome_paragraph_view')),
-        name='chrome_paragraph_view'),
+    url(r'^(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$', lt_cache(ChromeView.as_view(partial_class=PartialParagraphView, version_switch_view='chrome_paragraph_view')), name='chrome_paragraph_view'),
+
     # A regulation landing page
     # Example: http://.../201
-    url(r'^%s$' % reg_pattern, ChromeLandingView.as_view(),
-        name='regulation_landing_view'),
+    url(r'^(?P<label_id>[\d]+)$', ChromeLandingView.as_view(), name='regulation_landing_view'),
 
     # Load just the sidebar
     # Example: http://.../partial/sidebar/201-2/2013-10704
-    url(r'^partial/sidebar/%s/%s$' % (paragraph_pattern, version_pattern),
-        SideBarView.as_view(),
-        name='sidebar'),
+    url(r'^partial/sidebar/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$', SideBarView.as_view(), name='sidebar'),
 
     # Load just search results
-    url(r'^partial/search(?:/cfr)?/%s$' % reg_pattern,
-        PartialSearch.as_view(), name='partial_search',
-        kwargs={'doc_type': 'cfr'}),
-    url(r'^partial/search/preamble/%s$' % preamble_pattern,
-        PartialSearch.as_view(), name='partial_search',
-        kwargs={'doc_type': 'preamble'}),
+    url(r'^partial/search(?:/cfr)?/(?P<label_id>[\d]+)$', PartialSearch.as_view(), name='partial_search', kwargs={'doc_type': 'cfr'}),
+    url(r'^partial/search/preamble/(?P<label_id>[\w]+)$', PartialSearch.as_view(), name='partial_search', kwargs={'doc_type': 'preamble'}),
 
     # A diff view of a section (without chrome)
-    url(r'^partial/diff/%s/%s/%s$' % (
-        section_pattern, version_pattern, newer_version_pattern),
-        lt_cache(PartialSectionDiffView.as_view()),
-        name='partial_section_diff_view'),
+    url(r'^partial/diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$', lt_cache(PartialSectionDiffView.as_view()), name='partial_section_diff_view'),
+
     # A section by section paragraph (without chrome)
     # Example: http://.../partial/sxs/201-2-g/2011-1738
-    url(r'^partial/sxs/%s/%s$' % (paragraph_pattern, notice_pattern),
-        lt_cache(ParagraphSXSView.as_view()),
-        name='paragraph_sxs_view'),
+    url(r'^partial/sxs/(?P<label_id>[-\w]+)/(?P<notice_id>[-\d\w_]+)$', lt_cache(ParagraphSXSView.as_view()), name='paragraph_sxs_view'),
+
     # A definition templated to be displayed in the sidebar (without chrome)
     # Example: http://.../partial/definition/201-2-g/2011-1738
-    url(r'^partial/definition/%s/%s$' % (paragraph_pattern, version_pattern),
-        lt_cache(PartialDefinitionView.as_view()),
-        name='partial_definition_view'),
+    url(r'^partial/definition/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$', lt_cache(PartialDefinitionView.as_view()), name='partial_definition_view'),
+
     # A regulation section without chrome
     # Example: http://.../partial/201-4/2013-10704
-    url(r'^partial/%s/%s$' % (section_pattern, version_pattern),
-        lt_cache(PartialSectionView.as_view()),
-        name='partial_section_view'),
+    url(r'^partial/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$', lt_cache(PartialSectionView.as_view()), name='partial_section_view'),
+
     # Subterp, interpretations of a whole subpart, emptypart or appendices
     # Example: http://.../partial/201-Subpart-A-Interp/2013-10706
     #          http://.../partial/201-Subpart-Interp/2013-10706
     #          http://.../partial/201-Appendices-Interp/2013-10706
-    url(r'^partial/%s/%s$' % (subterp_pattern, version_pattern),
-        lt_cache(partial_interp.PartialSubterpView.as_view()),
-        name='partial_subterp_view'),
+    url(r'^partial/(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)/(?P<version>[-\d\w_]+)$', lt_cache(partial_interp.PartialSubterpView.as_view()), name='partial_subterp_view'),
+
     # An interpretation of a section/paragraph or appendix without chrome.
     # Example: http://.../partial/201-2-Interp/2013-10704
-    url(r'^partial/%s/%s$' % (interp_pattern, version_pattern),
-        lt_cache(partial_interp.PartialInterpView.as_view()),
-        name='partial_interp_view'),
+    url(r'^partial/(?P<label_id>[-\w]+[-]Interp)/(?P<version>[-\d\w_]+)$', lt_cache(partial_interp.PartialInterpView.as_view()), name='partial_interp_view'),
+
     # The whole regulation without chrome; not too useful; added for symmetry
     # Example: http://.../partial/201/2013-10704
-    url(r'^partial/%s/%s$' % (reg_pattern, version_pattern),
-        lt_cache(PartialRegulationView.as_view()),
-        name='partial_regulation_view'),
+    url(r'^partial/(?P<label_id>[\d]+)/(?P<version>[-\d\w_]+)$', lt_cache(PartialRegulationView.as_view()), name='partial_regulation_view'),
+
     # A regulation paragraph without chrome.
     # Example: http://.../partial/201-2-g/2013-10704
-    url(r'^partial/%s/%s$' % (paragraph_pattern, version_pattern),
-        lt_cache(PartialParagraphView.as_view()),
-        name='partial_paragraph_view'),
+    url(r'^partial/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$', lt_cache(PartialParagraphView.as_view()), name='partial_paragraph_view'),
 ]

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -27,63 +27,75 @@ from regulations.views.redirect import (
 from regulations.views.sidebar import SideBarView
 from regulations.views.universal_landing import universal
 
+# Reusable pattern matching constants to improve readability
+match_version = match_notice = r'[-\d\w_]+'
+match_section = r'[\d]+[-][\w]+'
+match_paragraph = r'[-\w]+'
+match_reg = r'[\d]+'
+match_preamble = r'[\w]+'
+match_paragraphs = r'[-\w]+(/[-\w]+)*'
+match_year = r'\d{4}'
+match_day = match_month = r'\d{2}'
+match_interp = r'[-\w]+[-]Interp'
+match_sub_interp = r'[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp'
+
 urlpatterns = [
     # Index page
     # Example http://.../
-    url(r'^$', universal, name='universal_landing'),
+    url(rf'^$', universal, name='universal_landing'),
 
     # About page
     # Example http://.../about
-    url(r'^about$', about, name='about'),
+    url(rf'^about$', about, name='about'),
 
     # Redirect to version by date (by GET)
     # Example http://.../regulation_redirect/201-3-v
-    url(r'^regulation_redirect/(?P<label_id>[-\w]+)$',
+    url(rf'^regulation_redirect/(?P<label_id>{match_paragraph})$',
         redirect_by_date_get, name='redirect_by_date_get'),
 
     # Redirect to a diff based on GET params
     # Example http://.../diff_redirect/201-3/old_version?new_version=new
-    url(r'^diff_redirect/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$',
+    url(rf'^diff_redirect/(?P<label_id>{match_section})/(?P<version>{match_version})$',
         diff_redirect, name='diff_redirect'),
 
     # A section by section paragraph with chrome
     # Example: http://.../sxs/201-2-g/2011-1738
-    url(r'^sxs/(?P<label_id>[-\w]+)/(?P<notice_id>[-\d\w_]+)$',
+    url(rf'^sxs/(?P<label_id>{match_paragraph})/(?P<notice_id>{match_notice})$',
         lt_cache(ChromeSXSView.as_view()), name='chrome_sxs_view'),
 
     # Search results for non-JS viewers
     # Example: http://.../search?q=term&version=2011-1738
-    url(r'^search(?:/cfr)?/(?P<label_id>[\d]+)$',
+    url(rf'^search(?:/cfr)?/(?P<label_id>{match_reg})$',
         ChromeSearchView.as_view(),
         name='chrome_search',
         kwargs={'doc_type': 'cfr'}),
-    url(r'^search/preamble/(?P<label_id>[\w]+)$',
+    url(rf'^search/preamble/(?P<label_id>{match_preamble})$',
         ChromePreambleSearchView.as_view(),
         name='chrome_search_preamble',
         kwargs={'doc_type': 'preamble'}),
 
     # Diff view of a section for non-JS viewers (or book markers)
     # Example: http://.../diff/201-4/2011-1738/2013-10704
-    url(r'^diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$',
+    url(rf'^diff/(?P<label_id>{match_section})/(?P<version>{match_version})/(?P<newer_version>{match_version})$',
         lt_cache(ChromeSectionDiffView.as_view()), name='chrome_section_diff_view'),
-    url(r'^preamble/(?P<doc_number>[\w-]+)/cfr_changes/(?P<section>[\w-]+)$',
+    url(rf'^preamble/(?P<doc_number>{match_paragraph})/cfr_changes/(?P<section>{match_paragraph})$',
         daily_cache(CFRChangesView.as_view()), name='cfr_changes'),
-    url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$',
+    url(rf'^preamble/(?P<paragraphs>{match_paragraphs})$',
         daily_cache(PreambleView.as_view()), name='chrome_preamble'),
 
     # Redirect to version by date
     # Example: http://.../201-3-v/1999/11/8
-    url(r'^(?P<label_id>[-\w]+)/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})$',
+    url(rf'^(?P<label_id>{match_paragraph})/(?P<year>{match_year})/(?P<month>{match_month})/(?P<day>{match_day})$',
         redirect_by_date, name='redirect_by_date'),
 
     # Redirect to version by current date
     # Example: http://.../201-3-v/CURRENT
-    url(r'^(?P<label_id>[-\w]+)/CURRENT$',
+    url(rf'^(?P<label_id>{match_paragraph})/CURRENT$',
         redirect_by_current_date, name='redirect_by_current_date'),
 
     # A regulation section with chrome
     # Example: http://.../201-4/2013-10704
-    url(r'^(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$',
+    url(rf'^(?P<label_id>{match_section})/(?P<version>{match_version})$',
         lt_cache(ChromeView.as_view(partial_class=PartialSectionView)),
         name='chrome_section_view'),
 
@@ -91,18 +103,18 @@ urlpatterns = [
     # Example: http://.../201-Subpart-A-Interp/2013-10706
     #          http://.../201-Subpart-Interp/2013-10706
     #          http://.../201-Appendices-Interp/2013-10706
-    url(r'^(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)/(?P<version>[-\d\w_]+)$',
+    url(rf'^(?P<label_id>{match_sub_interp})/(?P<version>{match_version})$',
         lt_cache(ChromeSubterpView.as_view()), name=ChromeSubterpView.version_switch_view),
 
     # Interpretation of a section/paragraph or appendix
     # Example: http://.../201-4-Interp/2013-10704
-    url(r'^(?P<label_id>[-\w]+[-]Interp)/(?P<version>[-\d\w_]+)$',
+    url(rf'^(?P<label_id>{match_interp})/(?P<version>{match_version})$',
         lt_cache(ChromeView.as_view(partial_class=partial_interp.PartialInterpView)),
         name='chrome_interp_view'),
 
     # The whole regulation with chrome
     # Example: http://.../201/2013-10704
-    url(r'^(?P<label_id>[\d]+)/(?P<version>[-\d\w_]+)$',
+    url(rf'^(?P<label_id>{match_reg})/(?P<version>{match_version})$',
         lt_cache(ChromeView.as_view(
             partial_class=PartialRegulationView,
             version_switch_view='chrome_regulation_view')),
@@ -110,7 +122,7 @@ urlpatterns = [
 
     # A regulation paragraph with chrome
     # Example: http://.../201-2-g/2013-10704
-    url(r'^(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
+    url(rf'^(?P<label_id>{match_paragraph})/(?P<version>{match_version})$',
         lt_cache(ChromeView.as_view(
             partial_class=PartialParagraphView,
             version_switch_view='chrome_paragraph_view')),
@@ -118,62 +130,62 @@ urlpatterns = [
 
     # A regulation landing page
     # Example: http://.../201
-    url(r'^(?P<label_id>[\d]+)$',
+    url(rf'^(?P<label_id>{match_reg})$',
         ChromeLandingView.as_view(), name='regulation_landing_view'),
 
     # Load just the sidebar
     # Example: http://.../partial/sidebar/201-2/2013-10704
-    url(r'^partial/sidebar/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
+    url(rf'^partial/sidebar/(?P<label_id>{match_paragraph})/(?P<version>{match_version})$',
         SideBarView.as_view(), name='sidebar'),
 
     # Load just search results
-    url(r'^partial/search(?:/cfr)?/(?P<label_id>[\d]+)$',
+    url(rf'^partial/search(?:/cfr)?/(?P<label_id>{match_reg})$',
         PartialSearch.as_view(),
         name='partial_search',
         kwargs={'doc_type': 'cfr'}),
-    url(r'^partial/search/preamble/(?P<label_id>[\w]+)$',
+    url(rf'^partial/search/preamble/(?P<label_id>{match_preamble})$',
         PartialSearch.as_view(),
         name='partial_search',
         kwargs={'doc_type': 'preamble'}),
 
     # A diff view of a section (without chrome)
-    url(r'^partial/diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$',
+    url(rf'^partial/diff/(?P<label_id>{match_section})/(?P<version>{match_version})/(?P<newer_version>{match_version})$',
         lt_cache(PartialSectionDiffView.as_view()), name='partial_section_diff_view'),
 
     # A section by section paragraph (without chrome)
     # Example: http://.../partial/sxs/201-2-g/2011-1738
-    url(r'^partial/sxs/(?P<label_id>[-\w]+)/(?P<notice_id>[-\d\w_]+)$',
+    url(rf'^partial/sxs/(?P<label_id>{match_paragraph})/(?P<notice_id>{match_notice})$',
         lt_cache(ParagraphSXSView.as_view()), name='paragraph_sxs_view'),
 
     # A definition templated to be displayed in the sidebar (without chrome)
     # Example: http://.../partial/definition/201-2-g/2011-1738
-    url(r'^partial/definition/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
+    url(rf'^partial/definition/(?P<label_id>{match_paragraph})/(?P<version>{match_version})$',
         lt_cache(PartialDefinitionView.as_view()), name='partial_definition_view'),
 
     # A regulation section without chrome
     # Example: http://.../partial/201-4/2013-10704
-    url(r'^partial/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$',
+    url(rf'^partial/(?P<label_id>{match_section})/(?P<version>{match_version})$',
         lt_cache(PartialSectionView.as_view()), name='partial_section_view'),
 
     # Subterp, interpretations of a whole subpart, emptypart or appendices
     # Example: http://.../partial/201-Subpart-A-Interp/2013-10706
     #          http://.../partial/201-Subpart-Interp/2013-10706
     #          http://.../partial/201-Appendices-Interp/2013-10706
-    url(r'^partial/(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)/(?P<version>[-\d\w_]+)$',
+    url(rf'^partial/(?P<label_id>{match_sub_interp})/(?P<version>{match_version})$',
         lt_cache(partial_interp.PartialSubterpView.as_view()), name='partial_subterp_view'),
 
     # An interpretation of a section/paragraph or appendix without chrome.
     # Example: http://.../partial/201-2-Interp/2013-10704
-    url(r'^partial/(?P<label_id>[-\w]+[-]Interp)/(?P<version>[-\d\w_]+)$',
+    url(rf'^partial/(?P<label_id>{match_interp})/(?P<version>{match_version})$',
         lt_cache(partial_interp.PartialInterpView.as_view()), name='partial_interp_view'),
 
     # The whole regulation without chrome; not too useful; added for symmetry
     # Example: http://.../partial/201/2013-10704
-    url(r'^partial/(?P<label_id>[\d]+)/(?P<version>[-\d\w_]+)$',
+    url(rf'^partial/(?P<label_id>{match_reg})/(?P<version>{match_version})$',
         lt_cache(PartialRegulationView.as_view()), name='partial_regulation_view'),
 
     # A regulation paragraph without chrome.
     # Example: http://.../partial/201-2-g/2013-10704
-    url(r'^partial/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
+    url(rf'^partial/(?P<label_id>{match_paragraph})/(?P<version>{match_version})$',
         lt_cache(PartialParagraphView.as_view()), name='partial_paragraph_view'),
 ]

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -38,99 +38,142 @@ urlpatterns = [
 
     # Redirect to version by date (by GET)
     # Example http://.../regulation_redirect/201-3-v
-    url(r'^regulation_redirect/(?P<label_id>[-\w]+)$', redirect_by_date_get, name='redirect_by_date_get'),
+    url(r'^regulation_redirect/(?P<label_id>[-\w]+)$',
+            redirect_by_date_get, name='redirect_by_date_get'),
 
     # Redirect to a diff based on GET params
     # Example http://.../diff_redirect/201-3/old_version?new_version=new
-    url(r'^diff_redirect/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$', diff_redirect, name='diff_redirect'),
+    url(r'^diff_redirect/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$',
+            diff_redirect, name='diff_redirect'),
 
     # A section by section paragraph with chrome
     # Example: http://.../sxs/201-2-g/2011-1738
-    url(r'^sxs/(?P<label_id>[-\w]+)/(?P<notice_id>[-\d\w_]+)$', lt_cache(ChromeSXSView.as_view()), name='chrome_sxs_view'),
+    url(r'^sxs/(?P<label_id>[-\w]+)/(?P<notice_id>[-\d\w_]+)$',
+            lt_cache(ChromeSXSView.as_view()), name='chrome_sxs_view'),
 
     # Search results for non-JS viewers
     # Example: http://.../search?q=term&version=2011-1738
-    url(r'^search(?:/cfr)?/(?P<label_id>[\d]+)$', ChromeSearchView.as_view(), name='chrome_search', kwargs={'doc_type': 'cfr'}),
-    url(r'^search/preamble/(?P<label_id>[\w]+)$', ChromePreambleSearchView.as_view(), name='chrome_search_preamble', kwargs={'doc_type': 'preamble'}),
+    url(r'^search(?:/cfr)?/(?P<label_id>[\d]+)$',
+            ChromeSearchView.as_view(),
+            name='chrome_search',
+            kwargs={'doc_type': 'cfr'}),
+    url(r'^search/preamble/(?P<label_id>[\w]+)$',
+            ChromePreambleSearchView.as_view(),
+            name='chrome_search_preamble',
+            kwargs={'doc_type': 'preamble'}),
  
     # Diff view of a section for non-JS viewers (or book markers)
     # Example: http://.../diff/201-4/2011-1738/2013-10704
-    url(r'^diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$', lt_cache(ChromeSectionDiffView.as_view()), name='chrome_section_diff_view'),
-    url(r'^preamble/(?P<doc_number>[\w-]+)/cfr_changes/(?P<section>[\w-]+)$', daily_cache(CFRChangesView.as_view()), name='cfr_changes'),
-    url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$', daily_cache(PreambleView.as_view()), name='chrome_preamble'),
+    url(r'^diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$',
+            lt_cache(ChromeSectionDiffView.as_view()), name='chrome_section_diff_view'),
+    url(r'^preamble/(?P<doc_number>[\w-]+)/cfr_changes/(?P<section>[\w-]+)$',
+            daily_cache(CFRChangesView.as_view()), name='cfr_changes'),
+    url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$',
+            daily_cache(PreambleView.as_view()), name='chrome_preamble'),
 
     # Redirect to version by date
     # Example: http://.../201-3-v/1999/11/8
-    url(r'^(?P<label_id>[-\w]+)/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})$', redirect_by_date, name='redirect_by_date'),
+    url(r'^(?P<label_id>[-\w]+)/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})$',
+            redirect_by_date, name='redirect_by_date'),
  
     # Redirect to version by current date
     # Example: http://.../201-3-v/CURRENT
-    url(r'^(?P<label_id>[-\w]+)/CURRENT$', redirect_by_current_date, name='redirect_by_current_date'),
+    url(r'^(?P<label_id>[-\w]+)/CURRENT$',
+            redirect_by_current_date, name='redirect_by_current_date'),
 
     # A regulation section with chrome
     # Example: http://.../201-4/2013-10704
-    url(r'^(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$', lt_cache(ChromeView.as_view(partial_class=PartialSectionView)), name='chrome_section_view'),
+    url(r'^(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$',
+            lt_cache(ChromeView.as_view(partial_class=PartialSectionView)),
+            name='chrome_section_view'),
         
     # Subterp, interpretations of a while subpart, emptypart or appendices
     # Example: http://.../201-Subpart-A-Interp/2013-10706
     #          http://.../201-Subpart-Interp/2013-10706
     #          http://.../201-Appendices-Interp/2013-10706
-    url(r'^(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)/(?P<version>[-\d\w_]+)$', lt_cache(ChromeSubterpView.as_view()), name=ChromeSubterpView.version_switch_view),
+    url(r'^(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)/(?P<version>[-\d\w_]+)$',
+            lt_cache(ChromeSubterpView.as_view()), name=ChromeSubterpView.version_switch_view),
 
     # Interpretation of a section/paragraph or appendix
     # Example: http://.../201-4-Interp/2013-10704
-    url(r'^(?P<label_id>[-\w]+[-]Interp)/(?P<version>[-\d\w_]+)$', lt_cache(ChromeView.as_view(partial_class=partial_interp.PartialInterpView)), name='chrome_interp_view'),
+    url(r'^(?P<label_id>[-\w]+[-]Interp)/(?P<version>[-\d\w_]+)$',
+            lt_cache(ChromeView.as_view(partial_class=partial_interp.PartialInterpView)),
+            name='chrome_interp_view'),
 
     # The whole regulation with chrome
     # Example: http://.../201/2013-10704
-    url(r'^(?P<label_id>[\d]+)/(?P<version>[-\d\w_]+)$', lt_cache(ChromeView.as_view(partial_class=PartialRegulationView, version_switch_view='chrome_regulation_view')), name='chrome_regulation_view'),
+    url(r'^(?P<label_id>[\d]+)/(?P<version>[-\d\w_]+)$',
+            lt_cache(ChromeView.as_view(
+                partial_class=PartialRegulationView,
+                version_switch_view='chrome_regulation_view')),
+            name='chrome_regulation_view'),
 
     # A regulation paragraph with chrome
     # Example: http://.../201-2-g/2013-10704
-    url(r'^(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$', lt_cache(ChromeView.as_view(partial_class=PartialParagraphView, version_switch_view='chrome_paragraph_view')), name='chrome_paragraph_view'),
+    url(r'^(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
+            lt_cache(ChromeView.as_view(
+                partial_class=PartialParagraphView,
+                version_switch_view='chrome_paragraph_view')),
+            name='chrome_paragraph_view'),
 
     # A regulation landing page
     # Example: http://.../201
-    url(r'^(?P<label_id>[\d]+)$', ChromeLandingView.as_view(), name='regulation_landing_view'),
+    url(r'^(?P<label_id>[\d]+)$',
+            ChromeLandingView.as_view(), name='regulation_landing_view'),
 
     # Load just the sidebar
     # Example: http://.../partial/sidebar/201-2/2013-10704
-    url(r'^partial/sidebar/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$', SideBarView.as_view(), name='sidebar'),
+    url(r'^partial/sidebar/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
+            SideBarView.as_view(), name='sidebar'),
 
     # Load just search results
-    url(r'^partial/search(?:/cfr)?/(?P<label_id>[\d]+)$', PartialSearch.as_view(), name='partial_search', kwargs={'doc_type': 'cfr'}),
-    url(r'^partial/search/preamble/(?P<label_id>[\w]+)$', PartialSearch.as_view(), name='partial_search', kwargs={'doc_type': 'preamble'}),
+    url(r'^partial/search(?:/cfr)?/(?P<label_id>[\d]+)$',
+            PartialSearch.as_view(),
+            name='partial_search',
+            kwargs={'doc_type': 'cfr'}),
+    url(r'^partial/search/preamble/(?P<label_id>[\w]+)$',
+            PartialSearch.as_view(),
+            name='partial_search',
+            kwargs={'doc_type': 'preamble'}),
 
     # A diff view of a section (without chrome)
-    url(r'^partial/diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$', lt_cache(PartialSectionDiffView.as_view()), name='partial_section_diff_view'),
+    url(r'^partial/diff/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)/(?P<newer_version>[-\d\w_]+)$',
+            lt_cache(PartialSectionDiffView.as_view()), name='partial_section_diff_view'),
 
     # A section by section paragraph (without chrome)
     # Example: http://.../partial/sxs/201-2-g/2011-1738
-    url(r'^partial/sxs/(?P<label_id>[-\w]+)/(?P<notice_id>[-\d\w_]+)$', lt_cache(ParagraphSXSView.as_view()), name='paragraph_sxs_view'),
+    url(r'^partial/sxs/(?P<label_id>[-\w]+)/(?P<notice_id>[-\d\w_]+)$',
+            lt_cache(ParagraphSXSView.as_view()), name='paragraph_sxs_view'),
 
     # A definition templated to be displayed in the sidebar (without chrome)
     # Example: http://.../partial/definition/201-2-g/2011-1738
-    url(r'^partial/definition/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$', lt_cache(PartialDefinitionView.as_view()), name='partial_definition_view'),
+    url(r'^partial/definition/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
+            lt_cache(PartialDefinitionView.as_view()), name='partial_definition_view'),
 
     # A regulation section without chrome
     # Example: http://.../partial/201-4/2013-10704
-    url(r'^partial/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$', lt_cache(PartialSectionView.as_view()), name='partial_section_view'),
+    url(r'^partial/(?P<label_id>[\d]+[-][\w]+)/(?P<version>[-\d\w_]+)$',
+            lt_cache(PartialSectionView.as_view()), name='partial_section_view'),
 
     # Subterp, interpretations of a whole subpart, emptypart or appendices
     # Example: http://.../partial/201-Subpart-A-Interp/2013-10706
     #          http://.../partial/201-Subpart-Interp/2013-10706
     #          http://.../partial/201-Appendices-Interp/2013-10706
-    url(r'^partial/(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)/(?P<version>[-\d\w_]+)$', lt_cache(partial_interp.PartialSubterpView.as_view()), name='partial_subterp_view'),
+    url(r'^partial/(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)/(?P<version>[-\d\w_]+)$',
+            lt_cache(partial_interp.PartialSubterpView.as_view()), name='partial_subterp_view'),
 
     # An interpretation of a section/paragraph or appendix without chrome.
     # Example: http://.../partial/201-2-Interp/2013-10704
-    url(r'^partial/(?P<label_id>[-\w]+[-]Interp)/(?P<version>[-\d\w_]+)$', lt_cache(partial_interp.PartialInterpView.as_view()), name='partial_interp_view'),
+    url(r'^partial/(?P<label_id>[-\w]+[-]Interp)/(?P<version>[-\d\w_]+)$',
+            lt_cache(partial_interp.PartialInterpView.as_view()), name='partial_interp_view'),
 
     # The whole regulation without chrome; not too useful; added for symmetry
     # Example: http://.../partial/201/2013-10704
-    url(r'^partial/(?P<label_id>[\d]+)/(?P<version>[-\d\w_]+)$', lt_cache(PartialRegulationView.as_view()), name='partial_regulation_view'),
+    url(r'^partial/(?P<label_id>[\d]+)/(?P<version>[-\d\w_]+)$',
+            lt_cache(PartialRegulationView.as_view()), name='partial_regulation_view'),
 
     # A regulation paragraph without chrome.
     # Example: http://.../partial/201-2-g/2013-10704
-    url(r'^partial/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$', lt_cache(PartialParagraphView.as_view()), name='partial_paragraph_view'),
+    url(r'^partial/(?P<label_id>[-\w]+)/(?P<version>[-\d\w_]+)$',
+            lt_cache(PartialParagraphView.as_view()), name='partial_paragraph_view'),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ omit = regulations/uitests/*,regulations/tests/*,fr_notices/tests/*,notice_comme
 
 [flake8]
 exclude = regulations/settings/*.py
+max-line-length = 130
 
 [isort]
 


### PR DESCRIPTION
As part of making things readable, we need to know exactly what is being matched with each URL without referring back to placeholder definitions.