### PR TITLE
EREGCSC-218 Correct paragraph markers in regulations-site

### DIFF
--- a/regulations/generator/layers/paragraph_markers.py
+++ b/regulations/generator/layers/paragraph_markers.py
@@ -56,7 +56,4 @@ class MarkerInfoLayer(ParagraphLayer):
     def attach_metadata(self, node):
         text_index = node['label_id']
         if self.layer_data.get(text_index):
-            original = self.layer_data[text_index][0]["text"]
-            stripped = original.replace('(', '').replace(')', '')
-            stripped = stripped.replace('.', '')
-            node['paragraph_marker'] = stripped
+            node['paragraph_marker'] = self.layer_data[text_index][0]["text"]

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -28,7 +28,7 @@
 
       {% block paragraph_marker %}
       {% if node.paragraph_marker %}
-        <span class="stripped-marker">{{node.paragraph_marker}}.</span>
+        <span class="stripped-marker">{{node.paragraph_marker}}</span>
       {% endif %}
       {% endblock %}
 

--- a/regulations/tests/layers_paragraph_markers_tests.py
+++ b/regulations/tests/layers_paragraph_markers_tests.py
@@ -50,8 +50,8 @@ class MarkerInfoLayerTest(TestCase):
 
         node['label_id'] = '1001-12-a'
         mil.attach_metadata(node)
-        self.assertEqual(node['paragraph_marker'], 'a')
+        self.assertEqual(node['paragraph_marker'], '(a)')
 
         node['label_id'] = '1001-12-q'
         mil.attach_metadata(node)
-        self.assertEqual(node['paragraph_marker'], 'q')
+        self.assertEqual(node['paragraph_marker'], 'q.')


### PR DESCRIPTION
Paragraphs should be displayed with parentheses instead of periods.

* Removed processing of paragraph markers within MarkerInfoLayer
This seems to correct the behavior but it does not fully remove MarkerInfoLayer.