### PR TITLE
EREGCSC-279 Added mixin for generating 'citation' key in context

### DIFF
--- a/regulations/templatetags/layers.py
+++ b/regulations/templatetags/layers.py
@@ -4,6 +4,7 @@ from regulations.generator import api_reader
 
 register = template.Library()
 
+
 @register.filter(name='internalcitation')
 def internalcitation(value, arg):
     if value == "":
@@ -20,7 +21,7 @@ def internalcitation(value, arg):
             original = value[citation["offsets"][0][0]:citation["offsets"][0][1]]
             # /433/section/112#433-112-c
             url = reverse("reader_view", args=[*citation["citation"][:2], version]) + "#" + "-".join(citation["citation"])
-            context = {"citation": citation["citation"], "original": original, "url": url }
+            context = {"citation": citation["citation"], "original": original, "url": url}
             rendered_citation = citation_template.render(context)
             value = value[:citation["offsets"][0][0]] + rendered_citation + value[citation["offsets"][0][1]:]
         return value

--- a/regulations/views/mixins.py
+++ b/regulations/views/mixins.py
@@ -32,3 +32,10 @@ class SidebarContextMixin:
             sidebar_class = getattr(import_module(module_name), class_name)
         sidebar = sidebar_class(label_id, version)
         return sidebar.full_context(self.client, self.request)
+
+class CitationContextMixin:
+    def get_context_data(self, **kwargs):
+        context = super(CitationContextMixin, self).get_context_data(**kwargs)
+        if 'part' in context and 'section' in context:
+            context['citation'] = f"{context['part']}-{context['section']}"
+        return context

--- a/regulations/views/mixins.py
+++ b/regulations/views/mixins.py
@@ -33,6 +33,7 @@ class SidebarContextMixin:
         sidebar = sidebar_class(label_id, version)
         return sidebar.full_context(self.client, self.request)
 
+
 class CitationContextMixin:
     def get_context_data(self, **kwargs):
         context = super(CitationContextMixin, self).get_context_data(**kwargs)

--- a/regulations/views/section.py
+++ b/regulations/views/section.py
@@ -27,20 +27,19 @@ class SectionView(SidebarContextMixin, CitationContextMixin, TemplateView):
 
         # getting url info (label and version)
         # answering the question: what are we looking at?
-        version = context['version']
+        reg_version = context["version"]
         reg_part = context["part"]
-        reg_section = context["section"]
-        label_id = context["citation"]
-        toc = self.get_toc(reg_part, version)
-        meta = utils.regulation_meta(reg_part, version)
-        tree = self.get_regulation(label_id, version)
+        reg_citation = context["citation"]
+        toc = self.get_toc(reg_part, reg_version)
+        meta = utils.regulation_meta(reg_part, reg_version)
+        tree = self.get_regulation(reg_citation, reg_version)
 
         if not meta:
             raise error_handling.MissingContentException()
 
         c = {
             'tree':                 tree,
-            'navigation':           self.get_neighboring_sections(label_id, version),
+            'navigation':           self.get_neighboring_sections(reg_citation, reg_version),
             'reg_part':             reg_part,
             'TOC':                  toc,
             'meta':                 meta,

--- a/regulations/views/section.py
+++ b/regulations/views/section.py
@@ -11,10 +11,10 @@ from regulations.generator.toc import fetch_toc
 from regulations.generator.section_url import SectionUrl
 from regulations.views import error_handling
 from regulations.views.chrome import version_span
-from regulations.views.mixins import SidebarContextMixin
+from regulations.views.mixins import SidebarContextMixin, CitationContextMixin
 
 
-class SectionView(SidebarContextMixin, TemplateView):
+class SectionView(SidebarContextMixin, CitationContextMixin, TemplateView):
 
     template_name = 'regulations/section.html'
 
@@ -30,7 +30,7 @@ class SectionView(SidebarContextMixin, TemplateView):
         version = context['version']
         reg_part = context["part"]
         reg_section = context["section"]
-        label_id = f"{reg_part}-{reg_section}"
+        label_id = context["citation"]
         toc = self.get_toc(reg_part, version)
         meta = utils.regulation_meta(reg_part, version)
         tree = self.get_regulation(label_id, version)

--- a/regulations/views/section.py
+++ b/regulations/views/section.py
@@ -3,14 +3,10 @@ from django.http import Http404
 
 from regulations.generator import api_reader
 from regulations.generator import generator
-from regulations.generator.html_builder import CFRHTMLBuilder
 from regulations.views import navigation, utils
-from regulations.generator.node_types import EMPTYPART, REGTEXT, label_to_text
-from regulations.generator.versions import fetch_grouped_history
 from regulations.generator.toc import fetch_toc
 from regulations.generator.section_url import SectionUrl
 from regulations.views import error_handling
-from regulations.views.chrome import version_span
 from regulations.views.mixins import SidebarContextMixin, CitationContextMixin
 
 


### PR DESCRIPTION
This allows us to avoid repeating code such as `label = f"{context['part']}-{context['section']}"`