### PR TITLE
EREGCSC-279 Added mixin for generating 'citation' key in context

### DIFF
--- a/regulations/views/mixins.py
+++ b/regulations/views/mixins.py
@@ -32,3 +32,10 @@ class SidebarContextMixin:
             sidebar_class = getattr(import_module(module_name), class_name)
         sidebar = sidebar_class(label_id, version)
         return sidebar.full_context(self.client, self.request)
+
+class CitationContextMixin:
+    def get_context_data(self, **kwargs):
+        context = super(CitationContextMixin, self).get_context_data(**kwargs)
+        if 'part' in context and 'section' in context:
+            context['citation'] = f"{context['part']}-{context['section']}"
+        return context

--- a/regulations/views/mixins.py
+++ b/regulations/views/mixins.py
@@ -33,6 +33,7 @@ class SidebarContextMixin:
         sidebar = sidebar_class(label_id, version)
         return sidebar.full_context(self.client, self.request)
 
+
 class CitationContextMixin:
     def get_context_data(self, **kwargs):
         context = super(CitationContextMixin, self).get_context_data(**kwargs)

--- a/regulations/views/section.py
+++ b/regulations/views/section.py
@@ -23,20 +23,19 @@ class SectionView(SidebarContextMixin, CitationContextMixin, TemplateView):
 
         # getting url info (label and version)
         # answering the question: what are we looking at?
-        version = context['version']
+        reg_version = context["version"]
         reg_part = context["part"]
-        reg_section = context["section"]
-        label_id = context["citation"]
-        toc = self.get_toc(reg_part, version)
-        meta = utils.regulation_meta(reg_part, version)
-        tree = self.get_regulation(label_id, version)
+        reg_citation = context["citation"]
+        toc = self.get_toc(reg_part, reg_version)
+        meta = utils.regulation_meta(reg_part, reg_version)
+        tree = self.get_regulation(reg_citation, reg_version)
 
         if not meta:
             raise error_handling.MissingContentException()
 
         c = {
             'tree':                 tree,
-            'navigation':           self.get_neighboring_sections(label_id, version),
+            'navigation':           self.get_neighboring_sections(reg_citation, reg_version),
             'reg_part':             reg_part,
             'TOC':                  toc,
             'meta':                 meta,

--- a/regulations/views/section.py
+++ b/regulations/views/section.py
@@ -7,10 +7,10 @@ from regulations.views import navigation, utils
 from regulations.generator.toc import fetch_toc
 from regulations.generator.section_url import SectionUrl
 from regulations.views import error_handling
-from regulations.views.mixins import SidebarContextMixin
+from regulations.views.mixins import SidebarContextMixin, CitationContextMixin
 
 
-class SectionView(SidebarContextMixin, TemplateView):
+class SectionView(SidebarContextMixin, CitationContextMixin, TemplateView):
 
     template_name = 'regulations/section.html'
 
@@ -26,7 +26,7 @@ class SectionView(SidebarContextMixin, TemplateView):
         version = context['version']
         reg_part = context["part"]
         reg_section = context["section"]
-        label_id = f"{reg_part}-{reg_section}"
+        label_id = context["citation"]
         toc = self.get_toc(reg_part, version)
         meta = utils.regulation_meta(reg_part, version)
         tree = self.get_regulation(label_id, version)


### PR DESCRIPTION
This allows us to avoid repeating code such as `label = f"{context['part']}-{context['section']}"`

