### PR TITLE
Don't link to unrecognized internal citations

### DIFF
--- a/regulations/templatetags/layers.py
+++ b/regulations/templatetags/layers.py
@@ -1,5 +1,5 @@
 from django import template
-from django.urls import reverse
+from django.urls import reverse, NoReverseMatch
 from regulations.generator import api_reader
 
 register = template.Library()
@@ -18,15 +18,17 @@ def internalcitation(value, arg):
         citations.sort(key=lambda x: x["offsets"][0][0], reverse=True)
         for citation in citations:
             original = value[citation["offsets"][0][0]:citation["offsets"][0][1]]
-            # /433/section/112#433-112-c
-            url = reverse("reader_view", args=[*citation["citation"][:2], version]) + "#" + "-".join(citation["citation"])
-            context = {
-                "citation": citation["citation"],
-                "original": original,
-                "url": url,
-            }
-            rendered_citation = citation_template.render(context)
-            value = value[:citation["offsets"][0][0]] + rendered_citation + value[citation["offsets"][0][1]:]
+            try:
+                # /433/section/112#433-112-c
+                url = reverse("reader_view", args=[*citation["citation"][:2], version]) + "#" + "-".join(citation["citation"])
+                context = {
+                    "citation": citation["citation"],
+                    "original": original,
+                    "url": url,
+                }
+                rendered_citation = citation_template.render(context)
+                value = value[:citation["offsets"][0][0]] + rendered_citation + value[citation["offsets"][0][1]:]
+            except NoReverseMatch:
+                pass
         return value
-    else:
-        return value
+    return value


### PR DESCRIPTION
Before this internal citations that referenced anything aside from a section caused the loading of the regulations text to fail. This change simply skips those citations that system can't understand them.