### PR TITLE
Django generates url for goto form

### DIFF
--- a/regulations/templates/regulations/section.html
+++ b/regulations/templates/regulations/section.html
@@ -26,7 +26,7 @@
     <aside class="left-sidebar">
         <div class="jump-to">
           <div class="jump-to-label">Jump to Regulation Section</div>
-          <form method="GET" action="/goto/">
+          <form method="GET" action="{% url 'goto' %}">
             <input name="part" type="hidden" required value={{ part }}>
             <input name="version" type="hidden" required value={{ version }}>
             <div class="jump-to-input">


### PR DESCRIPTION
Before this the form wouldn't work in hosting environments with a prefix to the path.